### PR TITLE
ci follow develop branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ "develop" ]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
現行のCIが追従するブランチをdevelopに変更する

開発中の好き勝手やる（DBにいろいろ手を入れたりとか）のはテスト用のデプロイでやる
これは現行のCI環境で追従するブランチをdevelopにすることで実現する

本番環境はmainブランチに追従させる
新たに本番用のCI環境を立ててworkflowを追加する