### PR TITLE
Update deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,8 @@ jobs:
       continue-on-error: true
       run: docker compose down
     - uses: actions/checkout@v3
+      with:
+        clean: false
     - name: Build&Up
       run: docker compose up --build -d
     - name: Wait


### PR DESCRIPTION
`.env`や`private_key`などの`.gitignore`対象ファイルがActionsでデプロイしたときに消えてしまう
checkout時にcleanされるのが原因
cleanしないように`deploy.yml`を修正した