### PR TITLE
選択メンバー変更時に購入履歴の更新がかかるように修正

### DIFF
--- a/frontend/src/HomePage/History/HistoryPane.tsx
+++ b/frontend/src/HomePage/History/HistoryPane.tsx
@@ -33,7 +33,7 @@ function HistoryPane({ selectedMember }: Props) {
 
   useEffect(() => {
     fetchHistoryData();
-  }, []);
+  }, [selectedMember]);
 
   return (
     <MainHistoryPane>


### PR DESCRIPTION
メンバーを選択しても購入履歴が取得されていなかった
多分リファクタリングのとき